### PR TITLE
Switching image URL in README to absolute to prevent broken link in box render

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![box-img-readme](box-img-readme.jpg)
+![box-img-readme](https://raw.githubusercontent.com/metamask/snap-box/master/box-img-readme.jpg)
 
 # @metamask/snap-box
 


### PR DESCRIPTION
## PR Description

As per the screenshot below, the boxes page ingests / renders the README from the box ([preview](https://bafybeialihbtubcc5bry5lpww3v4jux6usxeo4s2uqa6w4zc5phjrcanya.on.fleek.co/boxes/metamask-snap-box/)) and given it was a relative path before it was showing up as broken. This PR fixes it by switching it to an absolute path. 

<img width="1230" alt="Screen Shot 2022-11-16 at 11 11 20 AM" src="https://user-images.githubusercontent.com/210755/202247528-8cd77f55-eec8-4fe9-ac73-98e09e310589.png">
