### PR TITLE
Improving dependency installation for users that don't have Yarn 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ Before using this box, install Truffle and Ganache globally:
 npm install -g truffle ganache
 ```
 
+### Yarn v3
+
+This box also requires Yarn `v3` or later. If you're using Node.js 16 or later you'll be able to enable it by running the following command:
+
+```shell
+corepack enable
+```
+
+Details on setting up Yarn with earlier versions of Node.js can be found [here](https://yarnpkg.com/getting-started/install).
+
 ## Installation
 
 You can install this box with Truffle:

--- a/truffle-box.json
+++ b/truffle-box.json
@@ -7,6 +7,5 @@
     "Start": "yarn start"
   },
   "hooks": {
-    "post-unpack": "yarn install"
   }
 }


### PR DESCRIPTION
## Description

As highlighted in https://github.com/MetaMask/snap-box/issues/9, this PR addresses the issues impacting users that either don't have Yarn installed or are still on `v1.x`:

- content: adding reference to yarn 3 in the readme
- fix: rm the dep install from the post unpack hook

Note that although removing the `yarn install` from post-unpack hook makes the installation / setup a little less seamless, we'll at least be covered with the steps in the [pre-requisites](https://github.com/MetaMask/snap-box#pre-requisites).